### PR TITLE
Added bad list of bpos that can not be bought

### DIFF
--- a/wizardindustry/views.py
+++ b/wizardindustry/views.py
@@ -40,6 +40,23 @@ def index(request: WSGIRequest) -> HttpResponse:
 def _market_cycler(blueprint_marketgroups, owned_blueprints):
     models = []
 
+    bad_bpos = [
+        47969,
+        48469,
+        48470,
+        47971,
+        48471,
+        48472,
+        47973,
+        48473,
+        48474,
+        48095,
+        58973,
+        58974,
+        49973,
+        60514
+    ]
+
     for market_group in blueprint_marketgroups:
         market_group_view_model = owned_blueprints_market_groups()
         market_group_view_model.market_group_id = market_group.id
@@ -49,6 +66,9 @@ def _market_cycler(blueprint_marketgroups, owned_blueprints):
 
         for eve_type in market_group.eve_types.filter(published=True).all():
             if eve_type.name.startswith('Civilian'):
+                continue
+            
+            if eve_type.id in bad_bpos:
                 continue
 
             if eve_type is not None:


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed. Please also include
relevant motivation and context. List any dependencies that are required for this
change.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist:
This pull request includes changes to the `wizardindustry/views.py` file to improve the `_market_cycler` function by filtering out specific blueprint IDs that are considered bad.

Enhancements to blueprint filtering:

* [`wizardindustry/views.py`](diffhunk://#diff-b9e8faf2f2b150d8ffeb45218d2745bf79ce18151dd9b850cf381011a7678930R43-R59): Added a list of bad blueprint IDs (`bad_bpos`) to the `_market_cycler` function and included a condition to skip processing for these IDs. [[1]](diffhunk://#diff-b9e8faf2f2b150d8ffeb45218d2745bf79ce18151dd9b850cf381011a7678930R43-R59) [[2]](diffhunk://#diff-b9e8faf2f2b150d8ffeb45218d2745bf79ce18151dd9b850cf381011a7678930R71-R73)

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have checked my code and corrected any misspellings
